### PR TITLE
fix: hide blog posts using draft:true (Docusaurus)

### DIFF
--- a/website/blog/2026-05-05-tuning-up-copilot-context.md
+++ b/website/blog/2026-05-05-tuning-up-copilot-context.md
@@ -5,7 +5,7 @@ custom_edit_url: null
 sidebar_label: "2026.05.05 Tuning Up Copilot Context"
 title: "Copilot CLI Context Window: How I Cut Token Usage from 52% to 13%"
 description: "My context window was at 52% before typing a word. Here's how I found the biggest consumer, scoped it down, and got to 13%."
-published: false
+draft: true
 tags:
   - GitHub Copilot
   - Context Window

--- a/website/blog/2026-05-09-tuning-up-copilot-skills.md
+++ b/website/blog/2026-05-09-tuning-up-copilot-skills.md
@@ -5,7 +5,7 @@ custom_edit_url: null
 sidebar_label: "2026.05.09 Tuning Up Copilot Skills"
 title: "Optimizing Copilot Skills: 65% Token Reduction Across 117 Skills"
 description: "I had 413K tokens of unoptimized skills and a waza toolkit to diagnose them. Here's what I found, what surprised me, and what actually worked."
-published: false
+draft: true
 tags:
   - GitHub Copilot
   - Skills


### PR DESCRIPTION
Posts went live because \published: false\ is not a Docusaurus field. The correct field is \draft: true\.